### PR TITLE
Fix hydra scheduling errors

### DIFF
--- a/src/schema/job-job-message-create-schedule-clear.ts
+++ b/src/schema/job-job-message-create-schedule-clear.ts
@@ -17,13 +17,11 @@ export const jobJobMessageCreateScheduleClearInstall = (params: {
             v_params := JSONB_BUILD_OBJECT('name', p_name);
 
             INSERT INTO ${params.schema}.job (
-                name,
                 type, 
                 params,
                 is_recurring,
                 process_after
             ) VALUES (
-                p_name,
                 ${valueNode(JobType.JOB_MESSAGE_CREATE_SCHEDULE_CLEAR)},
                 v_params,
                 ${valueNode(false)},

--- a/src/schema/job-job-message-create-schedule-set.ts
+++ b/src/schema/job-job-message-create-schedule-set.ts
@@ -41,13 +41,11 @@ export const jobJobMessageCreateScheduleSetInstall = (params: {
             );
 
             INSERT INTO ${params.schema}.job (
-                name,
                 type, 
                 params,
                 is_recurring,
                 process_after
             ) VALUES (
-                p_name,
                 ${valueNode(JobType.JOB_MESSAGE_CREATE_SCHEDULE_SET)},
                 v_params,
                 ${valueNode(false)},


### PR DESCRIPTION
Jobs to set and clear scheduling (named jobs) shouldn't themselves have names